### PR TITLE
Implement basic status-driven classification pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-# ChEMBL_data_preprocessing
+# ChEMBL data preprocessing
+
+This project provides a small command line tool and library for
+reproducing parts of the ChEMBL activity classification pipeline using
+`pandas`.
+
+## Installation
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+```bash
+python classify.py --config config.yaml
+```
+
+Outputs are written into the directory configured under
+`io.output_dir`.

--- a/classify.py
+++ b/classify.py
@@ -1,0 +1,125 @@
+"""Command line interface for the classification pipeline."""
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+from pathlib import Path
+from typing import Any, Dict
+
+import yaml
+
+from constants import Cols
+from pipeline import (
+    Config,
+    aggregate_entities,
+    initialize_pairs,
+    initialize_status,
+    load_csv,
+    write_csv_with_meta,
+)
+from status_utils import StatusUtils
+
+DEFAULT_CONFIG = {
+    "io": {"input_dir": "input/same_document", "output_dir": "output"},
+    "status": {"empty_min_fallback": "GLOBAL_MIN"},
+    "runtime": {"fail_on_missing_columns": True, "float_na_fill": None},
+    "log": {"level": "INFO"},
+}
+
+
+def read_config(path: Path) -> Dict[str, Any]:
+    """Load configuration from *path* and apply environment overrides."""
+
+    cfg: Dict[str, Any] = DEFAULT_CONFIG.copy()
+    if path.exists():
+        with path.open("r", encoding="utf-8") as fh:
+            cfg.update(yaml.safe_load(fh) or {})
+    for env, val in os.environ.items():
+        if env.startswith("CLASSIFY__"):
+            keys = env[len("CLASSIFY__") :].lower().split("__")
+            ref = cfg
+            for k in keys[:-1]:
+                ref = ref.setdefault(k, {})
+            ref[keys[-1]] = val
+        elif env.startswith("CLASSIFY_"):
+            key = env[len("CLASSIFY_") :].lower()
+            if key in cfg.get("io", {}):
+                cfg["io"][key] = val
+    return cfg
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command line arguments."""
+
+    parser = argparse.ArgumentParser(description="Activity classification")
+    parser.add_argument("--config", default="config.yaml", type=Path)
+    parser.add_argument("--print-config", action="store_true")
+    parser.add_argument("--input-dir")
+    parser.add_argument("--output-dir")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    cfg_dict = read_config(args.config)
+    if args.input_dir:
+        cfg_dict.setdefault("io", {})["input_dir"] = args.input_dir
+    if args.output_dir:
+        cfg_dict.setdefault("io", {})["output_dir"] = args.output_dir
+    if args.print_config:
+        print(yaml.safe_dump(cfg_dict))
+        return 0
+
+    config = Config(**cfg_dict)  # type: ignore[arg-type]
+    logging.basicConfig(level=getattr(logging, config.log.get("level", "INFO")))
+
+    input_dir = Path(config.io["input_dir"])
+    output_dir = Path(config.io["output_dir"])
+
+    status_df = load_csv(input_dir / "status.csv")
+    activities_df = load_csv(input_dir / "activities.csv")
+    pairs_df = load_csv(input_dir / "pairs.csv")
+
+    utils = StatusUtils(status_df)
+    activities_init = initialize_status(
+        activities_df, utils, config.status.get("empty_min_fallback", "GLOBAL_MIN")
+    )
+    pairs_init = initialize_pairs(pairs_df, activities_init, utils)
+
+    entities = aggregate_entities(pairs_init, activities_init, utils)
+
+    sort_keys = {
+        "activity": Cols.ACTIVITY_ID,
+        "assay": Cols.ASSAY_ID,
+        "document": Cols.DOCUMENT_ID,
+        "system": Cols.SYSTEM_ID,
+        "testitem": Cols.TESTITEM_ID,
+        "target": Cols.TARGET_ID,
+    }
+
+    inputs = [
+        input_dir / "status.csv",
+        input_dir / "activities.csv",
+        input_dir / "pairs.csv",
+    ]
+
+    for name, df in entities.items():
+        key = sort_keys[name]
+        df_sorted = df.sort_values(key).reset_index(drop=True)
+        cols = [
+            key,
+            Cols.FILTERED_NEW,
+            Cols.INDEPENDENT_IC50,
+            Cols.NON_INDEPENDENT_IC50,
+            Cols.INDEPENDENT_KI,
+            Cols.NON_INDEPENDENT_KI,
+        ]
+        df_sorted = df_sorted[cols]
+        write_csv_with_meta(df_sorted, output_dir / f"{name}.csv", inputs, "1.0")
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,10 @@
+io:
+  input_dir: "input/same_document"
+  output_dir: "output"
+status:
+  empty_min_fallback: "GLOBAL_MIN"
+runtime:
+  fail_on_missing_columns: true
+  float_na_fill: null
+log:
+  level: "INFO"

--- a/constants.py
+++ b/constants.py
@@ -1,0 +1,27 @@
+"""Constants for column names used in the preprocessing pipeline."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Cols:
+    """String constants for dataframe column names."""
+
+    ACTIVITY_ID: str = "activity_id"
+    ACTIVITY_ID1: str = "activity_id1"
+    ACTIVITY_ID2: str = "activity_id2"
+    ASSAY_ID: str = "assay_id"
+    DOCUMENT_ID: str = "document_id"
+    TESTITEM_ID: str = "testitem_id"
+    TARGET_ID: str = "target_id"
+    MEASUREMENT_TYPE: str = "mesurement_type"
+    INDEPENDENT_IC50: str = "independent_IC50"
+    NON_INDEPENDENT_IC50: str = "non_independent_IC50"
+    INDEPENDENT_KI: str = "independent_Ki"
+    NON_INDEPENDENT_KI: str = "non_independent_Ki"
+    FILTERED: str = "Filtered"
+    FILTERED_INIT: str = "Filtered.init"
+    FILTERED_NEW: str = "Filtered.new"
+    NO_ISSUE: str = "no_issue"
+    SYSTEM_ID: str = "system_id"
+    TYPE: str = "type"

--- a/pipeline.py
+++ b/pipeline.py
@@ -1,0 +1,226 @@
+"""Data processing pipeline for activity classifications."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+import hashlib
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import pandas as pd
+import yaml
+
+from constants import Cols
+from status_utils import StatusUtils
+
+STATUS_FLAGS: List[str] = [
+    "high_citation_rate",
+    "unicellular_organism",
+    "review",
+    "rounded_data_citation",
+    "shuffled_assay",
+    "higly_correlated_assay",
+    "exact_data_citation",
+    "multmol_assay",
+    "multifunctional_enzyme",
+    "unknown_chirality",
+]
+
+
+@dataclass
+class Config:
+    """Configuration options for the pipeline."""
+
+    io: Dict[str, str]
+    status: Dict[str, str]
+    runtime: Dict[str, object]
+    log: Dict[str, str]
+
+
+# ---------------------------------------------------------------------------
+def load_csv(path: Path, dtype: Optional[Dict[str, str]] = None) -> pd.DataFrame:
+    """Load a CSV file using UTF-8 encoding."""
+
+    return pd.read_csv(path, dtype=dtype)
+
+
+def initialize_status(
+    activities: pd.DataFrame, status: StatusUtils, empty_fallback: str
+) -> pd.DataFrame:
+    """Add ``no_issue`` and ``Filtered.init`` columns to *activities*.
+
+    Parameters
+    ----------
+    activities:
+        Raw activities dataframe.
+    status:
+        :class:`StatusUtils` instance.
+    empty_fallback:
+        Behaviour when no flags are active. ``GLOBAL_MIN`` returns the
+        minimal status from the global order, ``ERROR`` raises ``ValueError``.
+    """
+
+    df = activities.copy()
+    df[Cols.NO_ISSUE] = ~df[STATUS_FLAGS].any(axis=1)
+
+    def _compute(row: pd.Series) -> str:
+        active_fields = [f for f in STATUS_FLAGS if row.get(f, False)]
+        valid = [f for f in active_fields if f in status.condition_fields]
+        if valid:
+            return status.get_min(valid)
+        if empty_fallback.upper() == "GLOBAL_MIN":
+            return status.status_list[0]
+        raise ValueError("no active status flags")
+
+    df[Cols.FILTERED_INIT] = df.apply(_compute, axis=1)
+    return df
+
+
+def initialize_pairs(
+    pairs: pd.DataFrame, activities: pd.DataFrame, status: StatusUtils
+) -> pd.DataFrame:
+    """Attach initial statuses from *activities* to *pairs* and compute ``Filtered``."""
+
+    left = pairs.merge(
+        activities[[Cols.ACTIVITY_ID, Cols.FILTERED_INIT]],
+        left_on=Cols.ACTIVITY_ID1,
+        right_on=Cols.ACTIVITY_ID,
+        how="left",
+    ).rename(columns={Cols.FILTERED_INIT: "Filtered1"})
+    left = left.drop(columns=[Cols.ACTIVITY_ID])
+    merged = left.merge(
+        activities[[Cols.ACTIVITY_ID, Cols.FILTERED_INIT]],
+        left_on=Cols.ACTIVITY_ID2,
+        right_on=Cols.ACTIVITY_ID,
+        how="left",
+    ).rename(columns={Cols.FILTERED_INIT: "Filtered2"})
+    merged = merged.drop(columns=[Cols.ACTIVITY_ID])
+    merged[Cols.FILTERED] = merged.apply(
+        lambda r: status.pair(r["Filtered1"], r["Filtered2"]), axis=1
+    )
+    return merged
+
+
+# ---------------------------------------------------------------------------
+def _agg_filtered(status: StatusUtils, series: pd.Series) -> str:
+    statuses = [s for s in series if isinstance(s, str)]
+    return status.get_max(statuses)
+
+
+def _aggregate(df: pd.DataFrame, group_col: str, status: StatusUtils) -> pd.DataFrame:
+    return (
+        df.groupby(group_col)
+        .agg(
+            {
+                Cols.FILTERED: lambda s: _agg_filtered(status, s),
+                Cols.INDEPENDENT_IC50: "sum",
+                Cols.NON_INDEPENDENT_IC50: "sum",
+                Cols.INDEPENDENT_KI: "sum",
+                Cols.NON_INDEPENDENT_KI: "sum",
+            }
+        )
+        .rename(columns={Cols.FILTERED: Cols.FILTERED_NEW})
+        .reset_index()
+    )
+
+
+def activity_from_pairs(pairs: pd.DataFrame) -> pd.DataFrame:
+    cols = [
+        Cols.ACTIVITY_ID1,
+        Cols.TESTITEM_ID,
+        Cols.TARGET_ID,
+        Cols.MEASUREMENT_TYPE,
+        Cols.FILTERED,
+        Cols.INDEPENDENT_IC50,
+        Cols.NON_INDEPENDENT_IC50,
+        Cols.INDEPENDENT_KI,
+        Cols.NON_INDEPENDENT_KI,
+    ]
+    left = pairs[cols].rename(columns={Cols.ACTIVITY_ID1: Cols.ACTIVITY_ID})
+    right = pairs[
+        [
+            Cols.ACTIVITY_ID2,
+            Cols.TESTITEM_ID,
+            Cols.TARGET_ID,
+            Cols.MEASUREMENT_TYPE,
+            Cols.FILTERED,
+            Cols.INDEPENDENT_IC50,
+            Cols.NON_INDEPENDENT_IC50,
+            Cols.INDEPENDENT_KI,
+            Cols.NON_INDEPENDENT_KI,
+        ]
+    ].rename(columns={Cols.ACTIVITY_ID2: Cols.ACTIVITY_ID})
+    unified = pd.concat([left, right], ignore_index=True).drop_duplicates()
+    unified = unified[
+        unified[Cols.ACTIVITY_ID].notna() & (unified[Cols.ACTIVITY_ID] != "")
+    ]
+    return unified
+
+
+def aggregate_entities(
+    pair_table: pd.DataFrame, activity_table: pd.DataFrame, status: StatusUtils
+) -> Dict[str, pd.DataFrame]:
+    """Return aggregated tables for all required entities."""
+
+    act_pairs = activity_from_pairs(pair_table)
+    activity = _aggregate(act_pairs, Cols.ACTIVITY_ID, status)
+
+    act_df = activity_table.rename(columns={Cols.FILTERED_INIT: Cols.FILTERED})
+    assay = _aggregate(act_df, Cols.ASSAY_ID, status)
+    document = _aggregate(act_df, Cols.DOCUMENT_ID, status)
+
+    sys_df = act_df.copy()
+    sys_df[Cols.SYSTEM_ID] = (
+        sys_df[Cols.TESTITEM_ID].astype(str)
+        + "_"
+        + sys_df[Cols.TARGET_ID].astype(str)
+        + "_"
+        + sys_df[Cols.MEASUREMENT_TYPE].astype(str)
+    )
+    system = _aggregate(sys_df, Cols.SYSTEM_ID, status)
+
+    ti_df = system.rename(columns={Cols.FILTERED_NEW: Cols.FILTERED}).copy()
+    ti_df[[Cols.TESTITEM_ID, Cols.TARGET_ID, Cols.TYPE]] = ti_df[
+        Cols.SYSTEM_ID
+    ].str.split("_", expand=True)
+    testitem = _aggregate(ti_df, Cols.TESTITEM_ID, status)
+
+    tar_df = system.rename(columns={Cols.FILTERED_NEW: Cols.FILTERED}).copy()
+    tar_df[[Cols.TESTITEM_ID, Cols.TARGET_ID, Cols.TYPE]] = tar_df[
+        Cols.SYSTEM_ID
+    ].str.split("_", expand=True)
+    target = _aggregate(tar_df, Cols.TARGET_ID, status)
+
+    return {
+        "activity": activity,
+        "assay": assay,
+        "document": document,
+        "system": system,
+        "testitem": testitem,
+        "target": target,
+    }
+
+
+# ---------------------------------------------------------------------------
+def write_csv_with_meta(
+    df: pd.DataFrame,
+    path: Path,
+    inputs: List[Path],
+    version: str,
+) -> None:
+    """Write ``df`` to ``path`` and create accompanying ``.meta.yaml``."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    csv_bytes = df.to_csv(index=False).encode("utf-8")
+    path.write_bytes(csv_bytes)
+
+    meta = {
+        "generated": datetime.utcnow().isoformat(),
+        "version": version,
+        "inputs": [str(p) for p in inputs],
+        "rows": int(df.shape[0]),
+        "cols": int(df.shape[1]),
+        "sha256": hashlib.sha256(csv_bytes).hexdigest(),
+    }
+    meta_path = path.with_suffix(".meta.yaml")
+    meta_path.write_text(yaml.safe_dump(meta))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pandas>=2.0
+pyyaml>=6.0

--- a/status_utils.py
+++ b/status_utils.py
@@ -1,0 +1,118 @@
+"""Utilities for working with activity statuses.
+
+This module exposes helper functions that mirror the behaviour of the
+Power Query (M) code used in the original data pipeline.  The functions
+operate on a status reference table with columns:
+
+```
+status, condition_field, condition_value, order, score
+```
+
+The table must already be validated and provided as a :class:`pandas.DataFrame`.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List
+
+import pandas as pd
+
+
+@dataclass
+class StatusUtils:
+    """Helper object providing status related utilities.
+
+    Parameters
+    ----------
+    table:
+        Status reference table containing at least the columns
+        ``status``, ``condition_field``, ``condition_value``, ``order`` and
+        ``score``.
+    """
+
+    table: pd.DataFrame
+
+    def __post_init__(self) -> None:  # pragma: no cover - simple assignments
+        self.table = self.table.sort_values("order").reset_index(drop=True)
+        self.status_list: List[str] = self.table["status"].tolist()
+        self.condition_fields: List[str] = self.table[
+            self.table["condition_value"] != "null"
+        ]["condition_field"].tolist()
+        self.order_map: Dict[str, int] = dict(
+            zip(self.table["status"], self.table["order"])
+        )
+        self.score_map: Dict[str, int] = dict(
+            zip(self.table["status"], self.table["score"])
+        )
+
+    # ------------------------------------------------------------------
+    def get_min(self, condition_fields: List[str]) -> str:
+        """Return the minimal status matching *condition_fields*.
+
+        Parameters
+        ----------
+        condition_fields:
+            List of field names that are ``True`` for the activity.
+
+        Returns
+        -------
+        str
+            Status name with the lowest ``order`` corresponding to one of
+            the supplied ``condition_field`` values.
+        """
+
+        subset = self.table[self.table["condition_field"].isin(condition_fields)]
+        if subset.empty:
+            raise ValueError("no statuses for given condition fields")
+        return subset.iloc[0]["status"]
+
+    def get_max(self, statuses: List[str]) -> str:
+        """Return the maximal status from ``statuses`` based on ``order``."""
+
+        subset = self.table[self.table["status"].isin(statuses)]
+        if subset.empty:
+            raise ValueError("no matching statuses")
+        return subset.sort_values("order").iloc[-1]["status"]
+
+    def pair(self, status1: str, status2: str) -> str:
+        """Return the higher priority status between *status1* and *status2*."""
+
+        subset = self.table[self.table["status"].isin([status1, status2])]
+        if subset.empty:
+            raise ValueError("unknown status in pair")
+        return subset.iloc[0]["status"]
+
+    def ascending(self, a: str, b: str) -> int:
+        """Comparator returning 1 if ``a`` > ``b`` in the global order."""
+
+        if a == b:
+            return 0
+        return 1 if self.order_map.get(a, -1) > self.order_map.get(b, -1) else -1
+
+    def descending(self, a: str, b: str) -> int:
+        """Comparator returning 1 if ``a`` < ``b`` in the global order."""
+
+        if a == b:
+            return 0
+        return -1 if self.order_map.get(a, -1) > self.order_map.get(b, -1) else 1
+
+    def next(self, status_name: str) -> str:
+        """Return the status following ``status_name`` in the global order."""
+
+        try:
+            idx = self.status_list.index(status_name)
+        except ValueError:
+            return self.status_list[-1]
+        if idx >= len(self.status_list) - 1:
+            return self.status_list[-1]
+        return self.status_list[idx + 1]
+
+    def get_order(self, status_name: str) -> int:
+        """Return the order of ``status_name`` or ``-1`` if unknown."""
+
+        return self.order_map.get(status_name, -1)
+
+    def get_score(self, status_name: str) -> int:
+        """Return the score of ``status_name`` or ``-1`` if unknown."""
+
+        return self.score_map.get(status_name, -1)

--- a/tests/data/activities.csv
+++ b/tests/data/activities.csv
@@ -1,0 +1,3 @@
+activity_id,assay_id,document_id,testitem_id,target_id,mesurement_type,independent_IC50,non_independent_IC50,independent_Ki,non_independent_Ki,high_citation_rate,unicellular_organism,review,rounded_data_citation,shuffled_assay,higly_correlated_assay,exact_data_citation,multmol_assay,multifunctional_enzyme,unknown_chirality
+a1,ass1,doc1,t1,tar1,type1,1,,2,,True,False,False,False,False,False,False,False,False,False
+a2,ass1,doc1,t1,tar1,type1,,3,,4,False,False,False,False,False,False,False,False,False,False

--- a/tests/data/pairs.csv
+++ b/tests/data/pairs.csv
@@ -1,0 +1,2 @@
+activity_id1,activity_id2,testitem_id,target_id,mesurement_type,independent_IC50,non_independent_IC50,independent_Ki,non_independent_Ki
+a1,a2,t1,tar1,type1,1,3,2,4

--- a/tests/data/status.csv
+++ b/tests/data/status.csv
@@ -1,0 +1,4 @@
+status,condition_field,condition_value,order,score
+S1,high_citation_rate,1,1,10
+S2,review,1,2,5
+S3,other,1,3,0

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,57 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from pipeline import aggregate_entities, initialize_pairs, initialize_status
+from status_utils import StatusUtils
+
+
+def load_data():
+    status = StatusUtils(pd.read_csv("tests/data/status.csv"))
+    activities = pd.read_csv(
+        "tests/data/activities.csv",
+        true_values=["True"],
+        false_values=["False"],
+    )
+    pairs = pd.read_csv("tests/data/pairs.csv")
+    return status, activities, pairs
+
+
+def test_initialize_status():
+    status, activities, _ = load_data()
+    init = initialize_status(activities, status, "GLOBAL_MIN")
+    assert init.loc[init["activity_id"] == "a1", "Filtered.init"].iat[0] == "S1"
+    assert init.loc[init["activity_id"] == "a2", "Filtered.init"].iat[0] == "S1"
+    assert init["no_issue"].tolist() == [False, True]
+
+
+def test_pairs_and_aggregates():
+    status, activities, pairs = load_data()
+    init_act = initialize_status(activities, status, "GLOBAL_MIN")
+    init_pairs = initialize_pairs(pairs, init_act, status)
+    assert init_pairs["Filtered"].iat[0] == "S1"
+
+    entities = aggregate_entities(init_pairs, init_act, status)
+    activity = entities["activity"]
+    assert activity.loc[activity["activity_id"] == "a1", "independent_IC50"].iat[0] == 1
+    assay = entities["assay"]
+    assert assay.loc[assay["assay_id"] == "ass1", "Filtered.new"].iat[0] == "S1"
+    document = entities["document"]
+    assert (
+        document.loc[document["document_id"] == "doc1", "non_independent_Ki"].iat[0]
+        == 4
+    )
+    system = entities["system"]
+    assert (
+        system.loc[system["system_id"] == "t1_tar1_type1", "independent_Ki"].iat[0] == 2
+    )
+    testitem = entities["testitem"]
+    assert (
+        testitem.loc[testitem["testitem_id"] == "t1", "non_independent_IC50"].iat[0]
+        == 3
+    )
+    target = entities["target"]
+    assert target.loc[target["target_id"] == "tar1", "independent_IC50"].iat[0] == 1

--- a/tests/test_status_utils.py
+++ b/tests/test_status_utils.py
@@ -1,0 +1,23 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from status_utils import StatusUtils
+
+
+def make_utils() -> StatusUtils:
+    df = pd.read_csv("tests/data/status.csv")
+    return StatusUtils(df)
+
+
+def test_basic_helpers():
+    utils = make_utils()
+    assert utils.get_min(["high_citation_rate"]) == "S1"
+    assert utils.get_max(["S1", "S3"]) == "S3"
+    assert utils.pair("S1", "S2") == "S1"
+    assert utils.next("S1") == "S2"
+    assert utils.get_order("S2") == 2
+    assert utils.get_score("S3") == 0


### PR DESCRIPTION
## Summary
- add `StatusUtils` with status ordering helpers
- implement pandas-based pipeline for initializing statuses, pairing activities and aggregating across entities
- provide CLI `classify.py` with config loading and output writer
- add tests and sample data

## Testing
- `black tests/test_status_utils.py tests/test_pipeline.py classify.py pipeline.py`  
- `ruff .`  
- `mypy .` *(fails: INTERNAL ERROR -- please try using mypy master on GitHub)*  
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c6c263a51483249a09b70c7f8aadae