### PR TITLE
Handle legacy column names in pair aggregation

### DIFF
--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -64,3 +64,22 @@ def test_pairs_and_aggregates():
     assert (
         target.loc[target["target_chembl_id"] == "tar1", "independent_IC50"].iat[0] == 1
     )
+
+
+def test_pairs_with_legacy_columns() -> None:
+    """``aggregate_entities`` handles pairs with legacy column names."""
+    status, activities, pairs = load_data()
+    legacy_pairs = pairs.rename(
+        columns={
+            "testitem_chembl_id": "molecule_chembl_id",
+            "mesurement_type": "standard_type",
+        }
+    )
+    init_act = initialize_status(activities, status, "GLOBAL_MIN")
+    init_pairs = initialize_pairs(legacy_pairs, init_act, status)
+    entities = aggregate_entities(init_pairs, init_act, status)
+    activity = entities["activity"]
+    assert (
+        activity.loc[activity["activity_chembl_id"] == "a1", "independent_IC50"].iat[0]
+        == 1
+    )


### PR DESCRIPTION
## Summary
- normalize legacy column names when extracting activities from pair tables
- extend pipeline tests to cover legacy column handling

## Testing
- `ruff check .`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6ca6d20848324b009d2198163f7d7