### PR TITLE
Handle missing activity count columns during aggregation

### DIFF
--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -6,6 +6,7 @@ import pandas as pd
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from pipeline import aggregate_entities, initialize_pairs, initialize_status
+from constants import Cols
 from status_utils import StatusUtils
 
 
@@ -64,3 +65,26 @@ def test_pairs_and_aggregates():
     assert (
         target.loc[target["target_chembl_id"] == "tar1", "independent_IC50"].iat[0] == 1
     )
+
+
+def test_aggregate_missing_count_columns():
+    status, activities, pairs = load_data()
+    # Remove count columns to simulate minimal input data
+    count_cols = [
+        Cols.INDEPENDENT_IC50,
+        Cols.NON_INDEPENDENT_IC50,
+        Cols.INDEPENDENT_KI,
+        Cols.NON_INDEPENDENT_KI,
+    ]
+    activities = activities.drop(columns=count_cols)
+    pairs = pairs.drop(columns=count_cols)
+
+    init_act = initialize_status(activities, status, "GLOBAL_MIN")
+    init_pairs = initialize_pairs(pairs, init_act, status)
+    entities = aggregate_entities(init_pairs, init_act, status)
+
+    # All outputs should contain the count columns filled with zeros
+    for df in entities.values():
+        for col in count_cols:
+            assert col in df.columns
+            assert df[col].sum() == 0


### PR DESCRIPTION
## Summary
- ensure activity count columns exist before aggregation to avoid KeyError
- aggregate pair-derived activities even when count columns are missing
- cover missing-column scenario with new regression test

## Testing
- `python -m black pipeline.py tests/test_pipeline.py`
- `ruff check pipeline.py tests/test_pipeline.py`
- `mypy pipeline.py tests/test_pipeline.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6cc5d95588324aad43336c5872dde