### PR TITLE
Add standalone classification CLI and fix column constants

### DIFF
--- a/classify.py
+++ b/classify.py
@@ -1,4 +1,5 @@
 """Command line interface for the classification pipeline."""
+
 from __future__ import annotations
 
 import argparse

--- a/constants.py
+++ b/constants.py
@@ -12,9 +12,14 @@ class Cols:
     ACTIVITY_ID2: str = "activity_chembl_id2"
     ASSAY_ID: str = "assay_chembl_id"
     DOCUMENT_ID: str = "document_chembl_id"
-    TESTITEM_ID: str = "molecule_chembl_id"
+    # ``testitem_chembl_id`` and ``mesurement_type`` are the canonical column
+    # names in the CSV files shipped with this project.  Historically some
+    # datasets used ``molecule_chembl_id`` and ``standard_type`` instead.  The
+    # pipeline handles these legacy names but exposes the modern identifiers as
+    # constants here.
+    TESTITEM_ID: str = "testitem_chembl_id"
     TARGET_ID: str = "target_chembl_id"
-    MEASUREMENT_TYPE: str = "standard_type"
+    MEASUREMENT_TYPE: str = "mesurement_type"
     INDEPENDENT_IC50: str = "independent_IC50"
     NON_INDEPENDENT_IC50: str = "non_independent_IC50"
     INDEPENDENT_KI: str = "independent_Ki"

--- a/main.py
+++ b/main.py
@@ -1,0 +1,136 @@
+"""Command line interface to classify activity data.
+
+This script mirrors the Power Query logic provided in the M script and
+exposes a small CLI for classifying activities, assays, documents and other
+entities.  The implementation relies on the functions defined in
+:mod:`pipeline` and :mod:`status_utils`.
+
+Example
+-------
+Run the classifier on the bundled example dataset::
+
+    python main.py --input input/same_document --output output
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+from typing import Iterable, List, Sequence
+
+import pandas as pd
+
+from constants import Cols
+from pipeline import (
+    aggregate_entities,
+    initialize_pairs,
+    initialize_status,
+    write_csv_with_meta,
+)
+from status_utils import StatusUtils
+
+
+def classify_directory(
+    input_dir: Path,
+    output_dir: Path,
+    *,
+    sep: str = ",",
+    encoding: str = "utf-8",
+    log_level: str = "INFO",
+) -> None:
+    """Classify activity data located in ``input_dir``.
+
+    Parameters
+    ----------
+    input_dir:
+        Directory containing ``status.csv``, ``activities.csv`` and
+        ``pairs.csv`` files.
+    output_dir:
+        Destination directory for the generated CSV files.
+    sep:
+        Field separator used by the input CSV files.  Defaults to ",".
+    encoding:
+        Encoding of the CSV files.  Defaults to ``"utf-8"``.
+    log_level:
+        Logging level passed to :func:`logging.basicConfig`.
+    """
+
+    logging.basicConfig(level=getattr(logging, log_level.upper(), logging.INFO))
+
+    # Load the raw input tables
+    status_df = pd.read_csv(input_dir / "status.csv", sep=sep, encoding=encoding)
+    activities_df = pd.read_csv(
+        input_dir / "activities.csv", sep=sep, encoding=encoding
+    )
+    pairs_df = pd.read_csv(input_dir / "pairs.csv", sep=sep, encoding=encoding)
+
+    utils = StatusUtils(status_df)
+
+    # Apply the status initialisation and pair logic
+    activities_init = initialize_status(activities_df, utils, "GLOBAL_MIN")
+    pairs_init = initialize_pairs(pairs_df, activities_init, utils)
+
+    # Aggregate to all required entity levels
+    entities = aggregate_entities(pairs_init, activities_init, utils)
+
+    # Map from entity name to primary sort key column
+    sort_keys = {
+        "activity": Cols.ACTIVITY_ID,
+        "assay": Cols.ASSAY_ID,
+        "document": Cols.DOCUMENT_ID,
+        "system": Cols.SYSTEM_ID,
+        "testitem": Cols.TESTITEM_ID,
+        "target": Cols.TARGET_ID,
+    }
+
+    inputs: List[Path] = [
+        input_dir / "status.csv",
+        input_dir / "activities.csv",
+        input_dir / "pairs.csv",
+    ]
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    for name, df in entities.items():
+        key = sort_keys[name]
+        df_sorted = df.sort_values(key).reset_index(drop=True)
+        cols = [
+            key,
+            Cols.FILTERED_NEW,
+            Cols.INDEPENDENT_IC50,
+            Cols.NON_INDEPENDENT_IC50,
+            Cols.INDEPENDENT_KI,
+            Cols.NON_INDEPENDENT_KI,
+        ]
+        df_sorted = df_sorted[cols]
+        write_csv_with_meta(df_sorted, output_dir / f"{name}.csv", inputs, "1.0")
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Return command line arguments."""
+
+    parser = argparse.ArgumentParser(description="Activity classification")
+    parser.add_argument("--input", type=Path, default=Path("input/same_document"))
+    parser.add_argument("--output", type=Path, default=Path("output"))
+    parser.add_argument("--log-level", default="INFO")
+    parser.add_argument("--sep", default=",")
+    parser.add_argument("--encoding", default="utf-8")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Script entry point."""
+
+    args = parse_args(argv)
+    classify_directory(
+        args.input,
+        args.output,
+        sep=args.sep,
+        encoding=args.encoding,
+        log_level=args.log_level,
+    )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import argparse
 import logging
 from pathlib import Path
-from typing import Iterable, List, Sequence
+from typing import List, Sequence
 
 import pandas as pd
 

--- a/pipeline.py
+++ b/pipeline.py
@@ -159,7 +159,6 @@ def _aggregate(df: pd.DataFrame, group_col: str, status: StatusUtils) -> pd.Data
 
 
 def activity_from_pairs(pairs: pd.DataFrame) -> pd.DataFrame:
-
     """Return a unified activity table built from *pairs*.
 
     The input ``pairs`` table may originate from different preprocessing
@@ -195,7 +194,6 @@ def activity_from_pairs(pairs: pd.DataFrame) -> pd.DataFrame:
                 break
     if rename_map:
         pairs = pairs.rename(columns=rename_map)
-
 
     cols = [
         Cols.ACTIVITY_ID1,

--- a/status_utils.py
+++ b/status_utils.py
@@ -10,6 +10,7 @@ status, condition_field, condition_value, order, score
 
 The table must already be validated and provided as a :class:`pandas.DataFrame`.
 """
+
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,20 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from main import classify_directory
+
+
+def test_classify_directory(tmp_path: Path) -> None:
+    """Running ``classify_directory`` creates expected output files."""
+    input_dir = Path("tests/data")
+    classify_directory(input_dir, tmp_path)
+    activity = pd.read_csv(tmp_path / "activity.csv")
+    assert "Filtered.new" in activity.columns
+    assert (
+        activity.loc[activity["activity_chembl_id"] == "a1", "independent_IC50"].iat[0]
+        == 1
+    )

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -83,3 +83,22 @@ def test_pairs_with_legacy_columns() -> None:
         activity.loc[activity["activity_chembl_id"] == "a1", "independent_IC50"].iat[0]
         == 1
     )
+
+
+def test_activities_with_legacy_columns() -> None:
+    """``initialize_status`` accepts activities with legacy column names."""
+    status, activities, pairs = load_data()
+    legacy_act = activities.rename(
+        columns={
+            "testitem_chembl_id": "test_item.id",
+            "mesurement_type": "measurement_type",
+        }
+    )
+    init_act = initialize_status(legacy_act, status, "GLOBAL_MIN")
+    init_pairs = initialize_pairs(pairs, init_act, status)
+    # ``aggregate_entities`` should succeed using the normalised columns
+    entities = aggregate_entities(init_pairs, init_act, status)
+    system = entities["system"]
+    assert (
+        system.loc[system["system_id"] == "t1_tar1_type1", "independent_Ki"].iat[0] == 2
+    )

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -6,7 +6,6 @@ import pandas as pd
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from pipeline import aggregate_entities, initialize_pairs, initialize_status
-from constants import Cols
 from status_utils import StatusUtils
 
 
@@ -67,7 +66,6 @@ def test_pairs_and_aggregates():
     )
 
 
-
 def test_pairs_with_legacy_columns() -> None:
     """``aggregate_entities`` handles pairs with legacy column names."""
     status, activities, pairs = load_data()
@@ -85,4 +83,3 @@ def test_pairs_with_legacy_columns() -> None:
         activity.loc[activity["activity_chembl_id"] == "a1", "independent_IC50"].iat[0]
         == 1
     )
-


### PR DESCRIPTION
## Summary
- add `main.py` providing a simple CLI to run the classification pipeline
- update column constants to use `testitem_chembl_id` and `mesurement_type`
- add regression test for new CLI

## Testing
- `ruff check .`
- `black --check .`
- `mypy .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6d5ea88388324bdcce4a95f8028b3