### PR TITLE
Merge activity pairs with InitializeStatus

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -215,25 +215,29 @@ def _aggregate(df: pd.DataFrame, group_col: str, status: StatusAPI) -> pd.DataFr
     )
 
 
-def activity_from_pairs(pairs: pd.DataFrame) -> pd.DataFrame:
+def activity_from_pairs(pairs: pd.DataFrame, init_status: pd.DataFrame) -> pd.DataFrame:
     """Return a unified activity table built from *pairs*.
 
     The input ``pairs`` table may originate from different preprocessing
     pipelines.  Some datasets use legacy column names such as
     ``molecule_chembl_id`` or ``standard_type`` instead of the canonical
     :data:`Cols.TESTITEM_ID` and :data:`Cols.MEASUREMENT_TYPE`.  This helper
-    normalises such variations before aggregating the activity information.
+    normalises such variations before aggregating the activity information and
+    finally merges the result with the ``InitializeStatus`` table.
 
     Parameters
     ----------
     pairs:
         Dataframe with pairwise activity information.
+    init_status:
+        Initialise status dataframe with ``Filtered.init`` and other metadata.
 
     Returns
     -------
     pandas.DataFrame
-        Deduplicated list of activities with the minimal set of columns
-        required for later aggregation steps.
+        Deduplicated list of activities merged with ``InitializeStatus`` and
+        containing the minimal set of columns required for later aggregation
+        steps.
     """
 
     # ``pairs`` may lack canonical column names when sourced from older
@@ -292,7 +296,20 @@ def activity_from_pairs(pairs: pd.DataFrame) -> pd.DataFrame:
     unified = unified[
         unified[Cols.ACTIVITY_ID].notna() & (unified[Cols.ACTIVITY_ID] != "")
     ]
-    return unified
+
+    # ``InitializeStatus`` already contains the count columns aggregated above.
+    # Remove them to avoid duplicated ``_x``/``_y`` suffixed columns after the
+    # merge.  Missing columns are ignored to keep the function robust with
+    # diverse inputs.
+    drop_cols = [
+        Cols.INDEPENDENT_IC50,
+        Cols.NON_INDEPENDENT_IC50,
+        Cols.INDEPENDENT_KI,
+        Cols.NON_INDEPENDENT_KI,
+    ]
+    status_cols = init_status.drop(columns=drop_cols, errors="ignore")
+    merged = unified.merge(status_cols, on=Cols.ACTIVITY_ID, how="left")
+    return merged
 
 
 def aggregate_entities(
@@ -300,7 +317,7 @@ def aggregate_entities(
 ) -> Dict[str, pd.DataFrame]:
     """Return aggregated tables for all required entities."""
 
-    act_pairs = activity_from_pairs(pair_table)
+    act_pairs = activity_from_pairs(pair_table, activity_table)
     activity = _aggregate(act_pairs, Cols.ACTIVITY_ID, status)
 
     act_df = activity_table.rename(columns={Cols.FILTERED_INIT: Cols.FILTERED})

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -5,8 +5,14 @@ import pandas as pd
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from pipeline import aggregate_entities, initialize_pairs, initialize_status
+from pipeline import (
+    activity_from_pairs,
+    aggregate_entities,
+    initialize_pairs,
+    initialize_status,
+)
 from status_utils import StatusUtils
+from constants import Cols
 
 
 def load_data():
@@ -70,6 +76,22 @@ def test_pairs_and_aggregates():
     assert (
         target.loc[target["target_chembl_id"] == "tar1", "independent_IC50"].iat[0] == 1
     )
+
+
+def test_activity_from_pairs_merges_status() -> None:
+    """``activity_from_pairs`` merges with ``InitializeStatus`` and keeps counts."""
+    status, activities, pairs = load_data()
+    init_act = initialize_status(activities, status, "GLOBAL_MIN")
+    init_pairs = initialize_pairs(pairs, init_act, status)
+    merged = activity_from_pairs(init_pairs, init_act)
+
+    # Columns from ``InitializeStatus`` are present
+    assert Cols.FILTERED_INIT in merged.columns
+    assert Cols.NO_ISSUE in merged.columns
+
+    # Count columns are not duplicated after the merge
+    assert "independent_IC50_x" not in merged.columns
+    assert "independent_IC50_y" not in merged.columns
 
 
 def test_pairs_with_legacy_columns() -> None:


### PR DESCRIPTION
## Summary
- merge activity pairs with InitializeStatus after dropping redundant count columns
- propagate InitializeStatus into aggregate_entities
- add regression test for new merge behaviour

## Testing
- `python -m black pipeline.py tests/test_pipeline.py`
- `ruff check .`
- `mypy .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6f7c352348324a90f49c0f91f43c3