### PR TITLE
Cache activity pair table for reuse

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,10 @@ pip install -r requirements.txt
 ## Usage
 
 ```bash
-python classify.py --config config.yaml
+python main.py --input input/same_document --output output
 ```
 
-Outputs are written into the directory configured under
-`io.output_dir`.
+The command generates intermediate tables `InitializeStatus.csv`,
+`InitializePairs.csv` and `ActivityInitializeStatus.csv` alongside the
+aggregated entity tables (e.g. `activity.csv`, `assay.csv`). Outputs are
+written into the directory given via `--output`.

--- a/pipeline.py
+++ b/pipeline.py
@@ -215,11 +215,9 @@ def _aggregate(df: pd.DataFrame, group_col: str, status: StatusAPI) -> pd.DataFr
     )
 
 
-
 def activity_from_pairs(
     pairs: pd.DataFrame, init_status: pd.DataFrame, status: StatusAPI
 ) -> pd.DataFrame:
-
     """Return a unified activity table built from *pairs*.
 
     The input ``pairs`` table may originate from different preprocessing
@@ -347,11 +345,29 @@ def activity_from_pairs(
 
 
 def aggregate_entities(
-    pair_table: pd.DataFrame, activity_table: pd.DataFrame, status: StatusAPI
+    pair_table: pd.DataFrame,
+    activity_table: pd.DataFrame,
+    status: StatusAPI,
+    act_pairs: pd.DataFrame | None = None,
 ) -> Dict[str, pd.DataFrame]:
-    """Return aggregated tables for all required entities."""
+    """Return aggregated tables for all required entities.
 
-    act_pairs = activity_from_pairs(pair_table, activity_table, status)
+    Parameters
+    ----------
+    pair_table:
+        Pairwise activity table produced by :func:`initialize_pairs`.
+    activity_table:
+        Activity table with initial status information.
+    status:
+        :class:`StatusAPI` instance used for status comparisons.
+    act_pairs:
+        Optional precomputed table returned by :func:`activity_from_pairs`.
+        Providing this avoids recomputing the table when it is already
+        available.
+    """
+
+    if act_pairs is None:
+        act_pairs = activity_from_pairs(pair_table, activity_table, status)
     activity = _aggregate(act_pairs, Cols.ACTIVITY_ID, status)
 
     act_df = activity_table.rename(columns={Cols.FILTERED_INIT: Cols.FILTERED})

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -24,3 +24,6 @@ def test_classify_directory(tmp_path: Path) -> None:
 
     init_pairs = pd.read_csv(tmp_path / "InitializePairs.csv")
     assert {"Filtered1", "Filtered2"}.issubset(init_pairs.columns)
+
+    act_pairs = pd.read_csv(tmp_path / "ActivityInitializeStatus.csv")
+    assert "Filtered.new" in act_pairs.columns

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -42,8 +42,8 @@ def test_pairs_and_aggregates():
     init_act = initialize_status(activities, status, "GLOBAL_MIN")
     init_pairs = initialize_pairs(pairs, init_act, status)
     assert init_pairs["Filtered"].iat[0] == "S1"
-
-    entities = aggregate_entities(init_pairs, init_act, status)
+    act_pairs = activity_from_pairs(init_pairs, init_act, status)
+    entities = aggregate_entities(init_pairs, init_act, status, act_pairs)
     activity = entities["activity"]
     assert (
         activity.loc[activity["activity_chembl_id"] == "a1", "independent_IC50"].iat[0]
@@ -79,13 +79,11 @@ def test_pairs_and_aggregates():
 
 
 def test_activity_from_pairs_merges_status() -> None:
-
     """``activity_from_pairs`` merges status and resolves final flags."""
     status, activities, pairs = load_data()
     init_act = initialize_status(activities, status, "GLOBAL_MIN")
     init_pairs = initialize_pairs(pairs, init_act, status)
     merged = activity_from_pairs(init_pairs, init_act, status)
-
 
     # Columns from ``InitializeStatus`` are present
     assert Cols.FILTERED_INIT in merged.columns
@@ -94,16 +92,13 @@ def test_activity_from_pairs_merges_status() -> None:
     # Pair-derived column is retained for comparison
     assert Cols.FILTERED_NEW in merged.columns
 
-
     # Count columns are not duplicated after the merge
     assert "independent_IC50_x" not in merged.columns
     assert "independent_IC50_y" not in merged.columns
 
-
     # ``Filtered`` is updated according to the status ordering rules
     row_a2 = merged.loc[merged[Cols.ACTIVITY_ID] == "a2"].iloc[0]
     assert row_a2[Cols.FILTERED] == "S2"
-
 
 
 def test_pairs_with_legacy_columns() -> None:


### PR DESCRIPTION
## Summary
- cache activity pair table in `main.py` and save as `ActivityInitializeStatus.csv`
- allow `aggregate_entities` to reuse a precomputed activity table
- document new CLI behaviour

## Testing
- `black main.py pipeline.py tests/test_pipeline.py tests/test_main.py`
- `ruff check main.py pipeline.py tests/test_pipeline.py tests/test_main.py README.md`
- `mypy main.py pipeline.py tests/test_pipeline.py tests/test_main.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c7021ef7908324bceb6c25bf327d64